### PR TITLE
Fixed a typo in the dataset link

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ Learning to generate distractors for multi-choice questions.
 
 Building cross-lingual models to generate questions in low-resource languages. 
 
-1. **Cross-Lingual Training for Automatic Question Generation.** ACL, 2019. [paper](https://arxiv.org/pdf/1906.02525.pdf) [dataset](https://www.cse.iitb.ac.in/̃ganesh/HiQuAD/clqg/)
+1. **Cross-Lingual Training for Automatic Question Generation.** ACL, 2019. [paper](https://arxiv.org/pdf/1906.02525.pdf) [dataset](https://www.cse.iitb.ac.in/~ganesh/HiQuAD/clqg/)
    
    *Vishwajeet Kumar, Nitish Joshi, Arijit Mukherjee, Ganesh Ramakrishnan, Preethi Jyothi*
 


### PR DESCRIPTION
Fixed a typo in the dataset link of "Cross-Lingual Training for Automatic Question Generation" paper